### PR TITLE
Update ocaml version to 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Once you do that, I recommend you setup an opam switch just for this project. Yo
 
 To create the switch:
 ```sh
-opam switch create diy-hazelnut 4.13.1
+opam switch create diy-hazelnut 5.2.0
 ```
 
 To set this switch as the currently active one:

--- a/lib/app.re
+++ b/lib/app.re
@@ -306,10 +306,7 @@ let view =
             };
 
           Node.button(
-            ~attr=
-              Attr.many_without_merge([
-                Attr.on_click(_ev => inject(actions)),
-              ]),
+            ~attrs=[Attr.on_click(_ev => inject(actions))],
             [Node.text(label)],
           );
         };
@@ -317,15 +314,14 @@ let view =
         let input_node = {
           let+ (input_location, input_value) = input;
           Node.input(
-            ~attr=
-              Attr.many_without_merge([
-                Attr.type_("text"),
-                Attr.string_property("value", input_value),
-                Attr.on_input((_ev, text) =>
-                  inject([Action.UpdateInput(input_location, text)])
-                ),
-              ]),
-            [],
+            ~attrs=[
+              Attr.type_("text"),
+              Attr.string_property("value", input_value),
+              Attr.on_input((_ev, text) =>
+                inject([Action.UpdateInput(input_location, text)])
+              ),
+            ],
+            (),
           );
         };
 


### PR DESCRIPTION
removed dependency on the old `[Html Element Name].(attr=Attr.many_without_merge)` style, updated to use the new list(Attr) as the updated library specifies.