### PR TITLE
add alcotest to make deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	dune clean
 
 deps:
-	opam install dune reason incr_dom ocaml-lsp-server
+	opam install dune reason incr_dom ocaml-lsp-server alcotest
 
 .PHONY: test
 test:


### PR DESCRIPTION
I couldn't run `make test` because I didn't have the alcotest library installed. I added it to the Makefile (`make deps`). I then tested `make deps` and alcotest was successfully installed. I was also able to run `make test` afterwards.